### PR TITLE
Marshal empty arrays instead of null

### DIFF
--- a/confidant/request.go
+++ b/confidant/request.go
@@ -17,6 +17,16 @@ type RequestBody struct {
 
 func (c *Client) Request(method string, path string, body *RequestBody, result interface{}) error {
 	url := c.url + path
+
+	if body != nil {
+		// Marshal empty arrays instead of "null".  The Confidant API expects these to be arrays.
+		if body.Credentials == nil {
+			body.Credentials = make([]string, 0)
+		}
+		if body.BlindCredentials == nil {
+			body.BlindCredentials = make([]string, 0)
+		}
+	}
 	requestBody, err := json.Marshal(body)
 	if err != nil {
 		return err

--- a/confidant/request_test.go
+++ b/confidant/request_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,6 +43,26 @@ func createHandlerFunc(t *testing.T, expectedUsername string, expectedToken stri
 		if expectedToken != token {
 			t.Errorf("Expected token %s, got %s", expectedToken, token)
 		}
+
+		// Check that we get empty arrays
+		var request RequestBody
+		bodyBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Unable read request body: %s", err)
+		}
+		if string(bodyBytes) != "null" {
+			err = json.Unmarshal(bodyBytes, &request)
+			if err != nil {
+				t.Errorf("Unable to unmarshal body: %s", err)
+			}
+			if request.Credentials == nil {
+				t.Errorf("Received nil credentials, wanted empty list")
+			}
+			if request.BlindCredentials == nil {
+				t.Errorf("Received nil blind credentials, wanted empty list")
+			}
+		}
+
 		json.NewEncoder(w).Encode(response)
 	}
 }


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Update README.md and example_test.go if necessary
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Marshal empty slices as arrays of size zero instead of nil.  Confidant assumes a value will be passed here.

#### Motivation
<!-- Why are you making this change? This can be a link to a GitHub Issue. -->
We've been getting a `NoneType` error at this line in pynamodb:
https://github.com/pynamodb/PynamoDB/blob/88368bb5379658022d0c284c65dcf7de428112b7/pynamodb/models.py#L265

Items is None there because it's a list of blind_credential_ids which gets passed in here:
https://github.com/lyft/confidant/blob/ca30f31b81a91e6203a1325e6a0f64f3f7379b64/confidant/routes/v1.py#L491
which comes from the request here:
https://github.com/lyft/confidant/blob/a652892b3664d25216d1b396205bd103eced1360/confidant/routes/v1.py#L299

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
I added unit tests. 

I created test IAM roles and then created test services with and without this change. (I needed to assign a credential, when there were no credentials assigned, it did not trigger).  With the change, I was able to successfully create the service. 

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Merge, then update the terraform provider.

r? @choo-stripe 
